### PR TITLE
Use Digest instead Digest::Digest

### DIFF
--- a/lib/ruby-mws/api/query.rb
+++ b/lib/ruby-mws/api/query.rb
@@ -17,7 +17,7 @@ module MWS
       end
 
       def signature
-        digest = OpenSSL::Digest::Digest.new('sha256')
+        digest = OpenSSL::Digest.new('sha256')
         key = @params[:secret_access_key]
         Base64.encode64(OpenSSL::HMAC.digest(digest, key, canonical)).chomp
       end


### PR DESCRIPTION
I received that warning in logs:

```
Digest::Digest is deprecated; use Digest
```

That PR should fix that.
